### PR TITLE
Improve CS2 tracker timezone handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Automatically track your Counter-Strike 2 gaming sessions and log them to Google
 - Logs gaming sessions to Google Calendar
 - Launches CS2 through Steam
 - Runs silently in the background
+- Events are logged using your system's local timezone
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- avoid psutil errors when detecting the game process
- use timezone-aware datetimes and log events in the local timezone
- document timezone behaviour in README

## Testing
- `python -m py_compile track_cs2.py setup_credentials.py`

------
https://chatgpt.com/codex/tasks/task_e_6878269d9cac832dac19e1db85bea917